### PR TITLE
Rename AssetsBucketPrefix default

### DIFF
--- a/cfn/classic/amm-master.cfn.json
+++ b/cfn/classic/amm-master.cfn.json
@@ -25,7 +25,7 @@
     "AssetsBucketPrefix": {
       "Description": "The prefix of the S3 bucket where the application WAR is located. A region-specific suffix will be appended, e.g. AssetsBucketPrefix-us-east-1.",
       "Type": "String",
-      "Default": "amm-"
+      "Default": "aws-amm-"
     },
     "WarKey": {
       "Description": "The key of the application WAR file in the WarBucket",

--- a/cfn/vpc/amm-master.cfn.json
+++ b/cfn/vpc/amm-master.cfn.json
@@ -90,7 +90,7 @@
     "AssetsBucketPrefix": {
       "Description": "The prefix of the S3 bucket where the application WAR is located. A region-specific suffix will be appended, e.g. AssetsBucketPrefix-us-east-1.",
       "Type": "String",
-      "Default" : "amm-"
+      "Default" : "aws-amm-"
     },
     "WarKey": {
       "Description": "The key of the application WAR file in the WarBucket",


### PR DESCRIPTION
This change renames the AssetsBucketPrefix for both `vpc/amm-master.cfn.json` and `classic/amm-master.cfn.json` to point to a new default bucket.
